### PR TITLE
Not activating the logger and not printing the `Requestty` error

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -48,7 +48,8 @@ impl ApcError {
     #[logfn(Debug)]
     #[logfn_inputs(Info)]
     pub fn print(&self) {
-        eprintln!("{}: {}", format!("{}Error", self.name()).red(), self)
+        (!matches!(self, Self::Requestty(_)))
+            .then(|| eprintln!("{}: {}", format!("{}Error", self.name()).red(), self));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,10 @@ mod config;
 mod errors;
 mod utils;
 
+use std::env::var;
+
 fn main() -> errors::Statuses<errors::ApcError> {
-    pretty_env_logger::init();
+    var("RUST_LOG").is_ok().then(|| pretty_env_logger::init());
     let alepc_config = config::get_config();
     if let Ok(alepc_config) = alepc_config {
         // Will run `errors::Statuses::report`-> `errors::ApcError::report`

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ mod utils;
 use std::env::var;
 
 fn main() -> errors::Statuses<errors::ApcError> {
-    var("RUST_LOG").is_ok().then(|| pretty_env_logger::init());
+    var("RUST_LOG").is_ok().then(pretty_env_logger::init);
     let alepc_config = config::get_config();
     if let Ok(alepc_config) = alepc_config {
         // Will run `errors::Statuses::report`-> `errors::ApcError::report`


### PR DESCRIPTION
## In this PR
- Unactivate the logger if no value is assigned to the environment variable `RUST_LOG ` to avoid log errors.
- Unprinting `Requestty` errors.

This will fixed #15
